### PR TITLE
Add section themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ helix-importer-ui
 .DS_Store
 *.bak
 .idea
+setup.js

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,76 +1,78 @@
-
 .hero-container > .hero-wrapper {
-  max-width: unset;
-  padding: 0;
-  display: flex; /* Enable flexbox for side-by-side layout */
-  flex-direction: row; /* Ensure text and image are side by side */
-  align-items: center; /* Vertically align items */
-  justify-content: space-between; /* Create space between text and image */
-  background: linear-gradient(to right, #f7e2e2 35%, #036 65%); /* Refine proportions */
+ flex-direction: column; /* Stack elements vertically */
 }
 
 .hero-container > .hero-wrapper > .hero > div {
-  display: flex; /* Enable flexbox for second-level layout */
-  flex-direction: row; /* Ensure second-level elements are side by side */
-  align-items: center; /* Vertically align items */
+  flex-direction: column; /* Stack second-level elements vertically */
+}
+
+.hero-container > .hero-wrapper > .hero > div > div {
+  max-width: 100%; /* Allow full width for both text and image */
+  padding: 0; /* Remove padding */
 }
 
 .hero-container > .hero-wrapper > .hero > div > div:first-child {
-  flex: 1; /* Allow the image container to take up half the space */
-  order: 2; /* Position the image on the right */
-  max-width: 50%; /* Restrict image container width */
-  display: flex; /* Enable flexbox within the image container */
   justify-content: center; /* Center the image */
   align-items: center; /* Align the image vertically */
 }
 
-.hero-container > .hero-wrapper > .hero > div > div:last-child {
-  flex: 1; /* Allow the text container to take up half the space */
-  order: 1; /* Position the text on the left */
-  max-width: 50%; /* Restrict text container width */
-  padding-left: 40px; /* Add spacing between text and image */
-  display: flex; /* Enable flexbox within text container */
-  flex-direction: column; /* Stack text elements vertically */
-  justify-content: center; /* Center text vertically */
-  align-items: flex-start; /* Align text to the left */
-}
-
 .hero-container > .hero-wrapper > .hero > div > div:first-child img {
-  object-fit: cover; /* Ensure the image is not stretched */
-  width: 100%; /* Make the image responsive */
+  width: 100%; /* Ensure image scales properly */
   height: auto; /* Maintain aspect ratio */
 }
 
-.hero-container > .hero-wrapper > .hero h1 {
-  margin: 0;
-  line-height: 1.2; /* Adjust line height */
-  font-size: var(--heading-font-size-l); /* Match font size */
-  color: #036;
-}
-
-.hero-container > .hero-wrapper > .hero p {
-  margin: 0 0 10px; /* Adjust spacing */
-  font-size: var(--body-font-size-s); /* Match font size */
-  color: #036;
-}
-
-@media (width <= 768px) {
+@media (width >= 960px) {
   .hero-container > .hero-wrapper {
-    flex-direction: column; /* Stack elements vertically */
-    padding: 20px; /* Add padding for smaller screens */
+    max-width: unset;
+    padding: 0;
+    display: flex; /* Enable flexbox for side-by-side layout */
+    flex-direction: row; /* Ensure text and image are side by side */
+    align-items: center; /* Vertically align items */
+    justify-content: space-between; /* Create space between text and image */
   }
-
+  
   .hero-container > .hero-wrapper > .hero > div {
-    flex-direction: column; /* Stack second-level elements vertically */
+    display: flex; /* Enable flexbox for second-level layout */
+    flex-direction: row; /* Ensure second-level elements are side by side */
+    align-items: center; /* Vertically align items */
   }
-
-  .hero-container > .hero-wrapper > .hero > div > div {
-    max-width: 100%; /* Allow full width for both text and image */
-    padding: 0; /* Remove padding */
+  
+  .hero-container > .hero-wrapper > .hero > div > div:first-child {
+    flex: 1; /* Allow the image container to take up half the space */
+    order: 2; /* Position the image on the right */
+    max-width: 50%; /* Restrict image container width */
+    display: flex; /* Enable flexbox within the image container */
+    justify-content: center; /* Center the image */
+    align-items: center; /* Align the image vertically */
   }
-
+  
+  .hero-container > .hero-wrapper > .hero > div > div:last-child {
+    flex: 1; /* Allow the text container to take up half the space */
+    order: 1; /* Position the text on the left */
+    max-width: 50%; /* Restrict text container width */
+    padding-left: 40px; /* Add spacing between text and image */
+    display: flex; /* Enable flexbox within text container */
+    flex-direction: column; /* Stack text elements vertically */
+    justify-content: center; /* Center text vertically */
+    align-items: flex-start; /* Align text to the left */
+  }
+  
   .hero-container > .hero-wrapper > .hero > div > div:first-child img {
-    width: 100%; /* Ensure image scales properly */
+    object-fit: cover; /* Ensure the image is not stretched */
+    width: 100%; /* Make the image responsive */
     height: auto; /* Maintain aspect ratio */
+  }
+  
+  .hero-container > .hero-wrapper > .hero h1 {
+    margin: 0;
+    line-height: 1.2; /* Adjust line height */
+    font-size: var(--heading-font-size-l); /* Match font size */
+    color: #036;
+  }
+  
+  .hero-container > .hero-wrapper > .hero p {
+    margin: 0 0 10px; /* Adjust spacing */
+    font-size: var(--body-font-size-s); /* Match font size */
+    color: #036;
   }
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -25,7 +25,6 @@
   margin: 0;
   line-height: 1.2; /* Adjust line height */
   font-size: var(--heading-font-size-xxl); /* Match font size */
-  color: #036;
 }
 
 .hero-container > .hero-wrapper > .hero p {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -21,10 +21,21 @@
   height: auto; /* Maintain aspect ratio */
 }
 
+.hero-container > .hero-wrapper > .hero h1 {
+  margin: 0;
+  line-height: 1.2; /* Adjust line height */
+  font-size: var(--heading-font-size-xxl); /* Match font size */
+  color: #036;
+}
+
+.hero-container > .hero-wrapper > .hero p {
+  margin: 0 0 10px; /* Adjust spacing */
+  font-size: var(--body-font-size-s); /* Match font size */
+}
+
 @media (width >= 960px) {
   .hero-container > .hero-wrapper {
-    max-width: unset;
-    padding: 0;
+    padding: 0 64px;
     display: flex; /* Enable flexbox for side-by-side layout */
     flex-direction: row; /* Ensure text and image are side by side */
     align-items: center; /* Vertically align items */
@@ -37,42 +48,8 @@
     align-items: center; /* Vertically align items */
   }
   
-  .hero-container > .hero-wrapper > .hero > div > div:first-child {
+  .hero-container > .hero-wrapper > .hero > div > div {
     flex: 1; /* Allow the image container to take up half the space */
-    order: 2; /* Position the image on the right */
     max-width: 50%; /* Restrict image container width */
-    display: flex; /* Enable flexbox within the image container */
-    justify-content: center; /* Center the image */
-    align-items: center; /* Align the image vertically */
-  }
-  
-  .hero-container > .hero-wrapper > .hero > div > div:last-child {
-    flex: 1; /* Allow the text container to take up half the space */
-    order: 1; /* Position the text on the left */
-    max-width: 50%; /* Restrict text container width */
-    padding-left: 40px; /* Add spacing between text and image */
-    display: flex; /* Enable flexbox within text container */
-    flex-direction: column; /* Stack text elements vertically */
-    justify-content: center; /* Center text vertically */
-    align-items: flex-start; /* Align text to the left */
-  }
-  
-  .hero-container > .hero-wrapper > .hero > div > div:first-child img {
-    object-fit: cover; /* Ensure the image is not stretched */
-    width: 100%; /* Make the image responsive */
-    height: auto; /* Maintain aspect ratio */
-  }
-  
-  .hero-container > .hero-wrapper > .hero h1 {
-    margin: 0;
-    line-height: 1.2; /* Adjust line height */
-    font-size: var(--heading-font-size-l); /* Match font size */
-    color: #036;
-  }
-  
-  .hero-container > .hero-wrapper > .hero p {
-    margin: 0 0 10px; /* Adjust spacing */
-    font-size: var(--body-font-size-s); /* Match font size */
-    color: #036;
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,7 @@ import {
   loadSection,
   loadSections,
   loadCSS,
+  createOptimizedPicture,
 } from './aem.js';
 
 /**
@@ -59,6 +60,22 @@ async function loadFonts() {
   }
 }
 
+function decorateSectionBackgrounds(main) {
+  main.querySelectorAll('.section[data-background]').forEach((section) => {
+    const { background } = section.dataset;
+    // if background is a picture, create an optimized picture
+    if (background.includes('media_')) { // if background is an embedded image
+      const backgroundPicture = createOptimizedPicture(background);
+      backgroundPicture.classList.add('section-background-image');
+      section.prepend(backgroundPicture);
+    } else if (background.startsWith('#')) { // if background is a hex color
+      section.style.backgroundColor = background;
+    } else if (background.includes('deg')) { // if background is a gradient
+      section.setAttribute('style', `background-image: linear-gradient(${background});`);
+    }
+  });
+}
+
 function buildPageDivider(main) {
   const allPageDivider = main.querySelectorAll('code');
 
@@ -101,6 +118,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  decorateSectionBackgrounds(main);
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -320,15 +320,18 @@ main > div > div {
 
 main > .section:first-of-type {
   margin-top: 0;
-}
-
-.section[data-theme] {
-  margin: 0;
+  padding-top: 0;
 }
 
 .section[data-background] {
   position: relative;
   margin: 0;
+  padding: 64px 0;
+}
+
+.section[data-theme] {
+  margin: 0;
+  padding-bottom: 5px;
 }
 
 .section[data-background] picture.section-background-image {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -147,7 +147,7 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 {
   font-size: var(--heading-font-size-xxl);
-  color: var(--c-teal);
+  color: var(--c-navy);
 }
 
 h2 {
@@ -302,10 +302,10 @@ main img {
   margin-left: 8px;
   height: 13px;
   width: 13px;
-  
 }
 
 /* sections */
+
 main>.section {
   margin: 40px 0;
 }
@@ -326,35 +326,36 @@ main > .section:first-of-type {
   margin: 0;
 }
 
-.section[data-theme='deep-teal-gradient'] {
+.section[data-background] {
+  position: relative;
+  margin: 0;
+}
+
+.section[data-background] picture.section-background-image {
+  position: absolute;
+  inset: 0;
+}
+
+.section[data-background] picture.section-background-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.section[data-theme='deep-teal'] {
   background-size: 100% 100%;
   background-position: 0 0,0 0;
   background-image: linear-gradient(6deg, #004A71 0%, #237C9A 49%, #35AEB6 100%);
   color: white;
-}
 
-.section[data-theme='light-salmon'] {
-  background-color: var(--c-light-salmon);
-}
-
-.section[data-theme='light-pink'] {
-  background-color: var(--c-light-pink);
-}
-
-.section[data-theme='light-teal-gradient'] {
-  background: linear-gradient(287deg, #e1e1ef, #88d7d4 82.41%);
-  
-  h1 {
-    color: var(--c-navy);
+  & h1 {
+    color: var(--c-teal);
   }
 }
 
-.section[data-theme='lightest-teal-gradient'] {
-  background: linear-gradient(180deg, #fff, #e7f6f5);
-}
-
 @media (width >= 768px) {
-  .section[data-theme='deep-teal-gradient'] {
+  .section[data-theme='deep-teal'] {
     background-size: 2880px 100%;
     background-position: 0 0,0 0;
     background-image: radial-gradient(78% 91% at 51% 96%, #004A71 21%, #0FF0 75%, #0FF0 100%),

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -23,6 +23,8 @@
   --c-soft-black: #1b252c;
   --c-teal: #88d7d4;
   --c-deep-teal: #00727f;
+  --c-light-salmon: #fdefe7;
+  --c-light-pink: #efeff7;
   --body-font-family: "Roboto", "Roboto Fallback", "sans-serif";
   --heading-font-family: "Roboto", "Roboto Fallback", "sans-serif";
   --heading-condensed-font-family: "Roboto Condensed", "Roboto Fallback", "sans-serif";
@@ -295,14 +297,55 @@ main>.section {
   margin: 40px 0;
 }
 
-main>.section>div {
-  max-width: 1200px;
-  margin: auto;
+main > div > div {
+  position: relative;
+  display: block;
+  max-width: 1440px;
   padding: 0 24px;
+  margin: 0 auto;
 }
 
 main>.section:first-of-type {
   margin-top: 0;
+}
+
+.section[data-theme] {
+  margin: 0;
+}
+
+.section[data-theme='deep-teal-gradient'] {
+  background-size: 100% 100%;
+  background-position: 0 0,0 0;
+  background-image: linear-gradient(6deg, #004A71 0%, #237C9A 49%, #35AEB6 100%);
+}
+
+.section[data-theme='light-salmon'] {
+  background-color: var(--c-light-salmon);
+}
+
+.section[data-theme='light-pink'] {
+  background-color: var(--c-light-pink);
+}
+
+.section[data-theme='light-teal-gradient'] {
+  background: linear-gradient(287deg, #e1e1ef, #88d7d4 82.41%);
+  
+  h1 {
+    color: var(--c-navy);
+  }
+}
+
+.section[data-theme='lightest-teal-gradient'] {
+  background: linear-gradient(180deg, #fff, #e7f6f5);
+}
+
+@media (width >= 768px) {
+  .section[data-theme='deep-teal-gradient'] {
+    background-size: 2880px 100%;
+    background-position: 0 0,0 0;
+    background-image: radial-gradient(78% 91% at 51% 96%, #004A71 21%, #0FF0 75%, #0FF0 100%),
+    linear-gradient(90deg, #6E90B6 0%, #3283A1 46%, #2FAAB2 100%);
+  }
 }
 
 @media (width>=900px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -269,7 +269,7 @@ a.button.secondary, button.secondary {
 }
 
 main img {
-  max-width: 100%;
+  max-height: 100%;
   width: auto;
   height: auto;
 }
@@ -300,12 +300,12 @@ main>.section {
 main > div > div {
   position: relative;
   display: block;
-  max-width: 1440px;
+  max-width: 1120px;
   padding: 0 24px;
   margin: 0 auto;
 }
 
-main>.section:first-of-type {
+main > .section:first-of-type {
   margin-top: 0;
 }
 
@@ -317,6 +317,7 @@ main>.section:first-of-type {
   background-size: 100% 100%;
   background-position: 0 0,0 0;
   background-image: linear-gradient(6deg, #004A71 0%, #237C9A 49%, #35AEB6 100%);
+  color: white;
 }
 
 .section[data-theme='light-salmon'] {
@@ -349,8 +350,14 @@ main>.section:first-of-type {
 }
 
 @media (width>=900px) {
-  main>.section>div {
-    padding: 0 32px;
+  main > div >div {
+    padding: 0 160px;
+  }
+}
+
+@media (width>=1200px) {
+  main > div >div {
+    padding: 64px clamp(24px, 11%, 160px);
   }
 }
 


### PR DESCRIPTION
There are 3 ways to use the data attribute of "background" in a section.
1. a solid hex color that starts with # 
2. a gradient that has 'deg' in the values. This must be a valid CSS dataset as whatever is entered becomes an inline style.
3. embed an image

Fix #11 

Test URLs:
- Before: https://main--biomarkerboost--aemdemos.aem.page/drafts/sections
- After: https://11-sections--biomarkerboost--aemdemos.aem.page/drafts/sections

How should your changes be tested:
The hero styles are not in scope; my edits to it were to reorder the CSS and remove some items that I put in the section styling instead.
compare with original site pages like https://biomarkerboost.com/how-testing-works
