### PR TITLE
28 - Fix left-align on footnote text

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -48,6 +48,7 @@
 
 .cards-wrapper + .default-content-wrapper > p {
   font-size: 12px; /* Adjust font size for footnote text following cards */
+  text-align: left; /* fix footnote alignment */
 }
 
 .cards-wrapper > .cards.block > ul > li .cards-card-body p {


### PR DESCRIPTION
Fix #28 

Test URLs:
- Before: https://main--biomarkerboost--aemdemos.aem.page/why-biomarkers-matter
- After: https://28-cards-salmon--biomarkerboost--aemdemos.aem.page/why-biomarkers-matter

How should your changes be tested:
Ensure footnote below salmon cards is left-aligned.