### PR TITLE
32 del style

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -61,11 +61,9 @@
 .default-content-wrapper h2 {
   font-size: 30px; /* Large font size for title */
   font-weight: bold; /* Bold text for emphasis */
-  color: var(--c-citrus); /* Navy blue text color */
   margin-bottom: 1rem; /* Add spacing below title */
 }
 
 .accordion-item-label h3 {
-  color: var(--c-navy);
   margin-right: 32px;
 }

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -65,5 +65,6 @@
 }
 
 .accordion-item-label h3 {
+  color: var(--c-navy);
   margin-right: 32px;
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -115,26 +115,6 @@ function prependSkipToMainLink(main) {
   skipToMainLink.innerText = 'Skip to main content';
   main.insertAdjacentElement('beforebegin', skipToMainLink);
 }
-/**
- * Function to change the color of all <del> elements contained in any heading element
- * and has the color var(--c-navy) to var(--c-citrus) or viceversa, and remove any text decoration
-  * @param {Element} main The container element
-  */
-function changeStrikethroughTextColor(main) {
-  const headings = main.querySelectorAll('h1, h2, h3, h4, h5, h6');
-  headings.forEach((heading) => {
-    const strikethroughs = heading.querySelectorAll('del');
-    strikethroughs.forEach((strikethrough) => {
-      strikethrough.style.textDecoration = 'none';
-      const computedColor = window.getComputedStyle(strikethrough).color;
-      if (computedColor === 'rgb(0, 75, 110)') { // var(--c-navy) in RGB
-        strikethrough.style.color = 'var(--c-citrus)';
-      } else if (computedColor === 'rgb(239, 95, 23)') { // var(--c-citrus) in RGB
-        strikethrough.style.color = 'var(--c-navy)';
-      }
-    });
-  });
-}
 
 /**
  * Decorates the main element.
@@ -165,7 +145,6 @@ async function loadEager(doc) {
     prependSkipToMainLink(main);
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
-    changeStrikethroughTextColor(main);
   }
 
   try {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -115,8 +115,9 @@ function prependSkipToMainLink(main) {
   skipToMainLink.innerText = 'Skip to main content';
   main.insertAdjacentElement('beforebegin', skipToMainLink);
 }
-
-/**Function to change the color of all <del> elements contained in any heading element, and has the color var(--c-navy) to var(--c-citrus) or viceversa, and remove any other text decoration 
+/**
+ * Function to change the color of all <del> elements contained in any heading element
+ * and has the color var(--c-navy) to var(--c-citrus) or viceversa, and remove any text decoration
   * @param {Element} main The container element
   */
 function changeStrikethroughTextColor(main) {
@@ -184,14 +185,11 @@ async function loadEager(doc) {
 async function loadLazy(doc) {
   const main = doc.querySelector('main');
   await loadSections(main);
-
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
-
   loadHeader(doc.querySelector('header'));
   loadFooter(doc.querySelector('footer'));
-
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -116,6 +116,25 @@ function prependSkipToMainLink(main) {
   main.insertAdjacentElement('beforebegin', skipToMainLink);
 }
 
+/**Function to change the color of all <del> elements contained in any heading element, and has the color var(--c-navy) to var(--c-citrus) or viceversa, and remove any other text decoration 
+  * @param {Element} main The container element
+  */
+function changeStrikethroughTextColor(main) {
+  const headings = main.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  headings.forEach((heading) => {
+    const strikethroughs = heading.querySelectorAll('del');
+    strikethroughs.forEach((strikethrough) => {
+      strikethrough.style.textDecoration = 'none';
+      const computedColor = window.getComputedStyle(strikethrough).color;
+      if (computedColor === 'rgb(0, 75, 110)') { // var(--c-navy) in RGB
+        strikethrough.style.color = 'var(--c-citrus)';
+      } else if (computedColor === 'rgb(239, 95, 23)') { // var(--c-citrus) in RGB
+        strikethrough.style.color = 'var(--c-navy)';
+      }
+    });
+  });
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -145,6 +164,7 @@ async function loadEager(doc) {
     prependSkipToMainLink(main);
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
+    changeStrikethroughTextColor(main);
   }
 
   try {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -160,6 +160,11 @@ h1 {
   color: var(--c-navy);
 }
 
+h1 > del {
+  color: var(--c-citrus);
+  text-decoration: none;
+}
+
 h2 {
   font-size: var(--heading-font-size-xl);
   color: var(--c-navy);
@@ -168,10 +173,20 @@ h2 {
   margin-bottom: 24px;
 }
 
+h2 > del {
+  color: var(--c-citrus);
+  text-decoration: none;
+}
+
 h3 {
   font-size: var(--heading-font-size-l);
   color: var(--c-citrus);
   line-height: 36px;
+}
+
+h3 > del {
+  color: var(--c-navy);
+  text-decoration: none;
 }
 
 h4 {
@@ -182,14 +197,29 @@ h4 {
   margin-bottom: 12px;
 }
 
+h4 > del {
+  color: var(--c-navy);
+  text-decoration: none;
+}
+
 h5 {
   font-size: var(--heading-font-size-s);
   color: var(--c-navy);
 }
 
+h5 > del {
+  color: var(--c-citris);
+  text-decoration: none;
+}
+
 h6 {
   font-size: var(--heading-font-size-xs);
   color: var(--c-citrus);
+}
+
+h6 > del {
+  color: var(--c-navy);
+  text-decoration: none;
 }
 
 sup {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -208,7 +208,7 @@ h5 {
 }
 
 h5 > del {
-  color: var(--c-citris);
+  color: var(--c-citrus);
   text-decoration: none;
 }
 


### PR DESCRIPTION
Added function to switch heading text colors if it's strikethrough. Removed unnecessary acordeon styles.

Fix #32 

Test URLs:
- Before: https://main--biomarkerboost--aemdemos.aem.page/
- After: https://32-del-style--biomarkerboost--aemdemos.aem.page/how-testing-works

How should your changes be tested:
Check out hero and acordeon header to see it in action. But in the docx i had to strikethrough a lot, not sure this is what you were going for:
<img width="724" alt="image" src="https://github.com/user-attachments/assets/9adbf978-7c46-4786-89dd-e95a19604eca" />

