### PR TITLE
allow authors to align cell content

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -17,7 +17,6 @@
 
 @media (width >= 900px) {
   .columns > div {
-    align-items: center;
     flex-direction: unset;
     gap: 24px;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -321,6 +321,37 @@ main img {
   width: 13px;
 }
 
+/* Alignment of authored block cells */
+.center, [data-align="center"] {
+  text-align: center;
+    background-position-x: center;
+}
+
+[data-valign="bottom"] {
+    align-content: end;
+    background-position-y: bottom;
+}
+
+[data-valign="middle"] {
+    align-content: center;
+    background-position-y: center;
+}
+
+[data-valign="top"] {
+    align-content: start;
+    background-position-y: top;
+}
+
+[data-align="right"] {
+    text-align: right;
+    background-position-x: right;
+}
+
+[data-align="left"], [data-align="justify"] {
+    text-align: left;
+    background-position-x: left;
+}
+
 /* sections */
 
 main>.section {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/251fcdc5-2dfa-4a49-aba6-d6f245ffc215)

After:
![image](https://github.com/user-attachments/assets/fb428260-3eef-4b95-8684-26be810d2a64)

Before:
(after turning off the center code that shouldn't be coming from the footer, see #34 )
![image](https://github.com/user-attachments/assets/d9fa8c62-3a7b-4dd0-967a-423b46269f98)

After:
![image](https://github.com/user-attachments/assets/ef45ff0a-3824-4f45-989d-2f2536487119)


Fix #36

Test URLs:
- Before: https://main--biomarkerboost--aemdemos.aem.page/how-testing-works
- After: https://36-alignments--biomarkerboost--aemdemos.aem.page/how-testing-works
